### PR TITLE
Updated ux and compatibility with the distributions

### DIFF
--- a/packages/volto-image-editor/news/+uxImprovement.internal
+++ b/packages/volto-image-editor/news/+uxImprovement.internal
@@ -1,0 +1,1 @@
+Updated according to the figma-design and improved styles for usage with the distributions @TimoBroeskamp

--- a/packages/volto-image-editor/src/components/ImageEditor/Editor/ImageEditor.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/Editor/ImageEditor.scss
@@ -2,7 +2,6 @@
 @import '../../../theme/variables';
 @import '../../../theme/constants';
 
-
 .image-widget .image-widget-cropper {
   button {
     padding: 20px 0px;

--- a/packages/volto-image-editor/src/components/ImageEditor/Editor/ImageEditor.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/Editor/ImageEditor.scss
@@ -2,9 +2,32 @@
 @import '../../../theme/variables';
 @import '../../../theme/constants';
 
+body.view-editview .react-aria-Modal.image-cropper-modal {
+  max-width: unset;
+  width: 70vw;
+  height: 70vh;
+}
+
+.image-widget .image-widget-cropper {
+  button {
+    border: none;
+    text-decoration: underline;
+    padding: 20px 0px;
+    color: rgba(0, 0, 0, 0.9);
+  }
+}
+
+.ui.grid.image-widget-grid .file-widget-dropzone img {
+  margin-top: 0px;
+}
+
 .image-editor {
   width: 100%;
+  height: 100%;
   color: $settings-header-color;
+  display: grid;
+  grid-template-columns: 100%;
+  grid-template-rows: 1fr 80px;
 
   &__preview {
     position: absolute;
@@ -19,7 +42,7 @@
 
   &__cropper {
     position: relative;
-    height: 500px;
+    height: 100%;
     max-height: 100vh;
     background: $color-gray-dark;
 

--- a/packages/volto-image-editor/src/components/ImageEditor/Editor/ImageEditor.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/Editor/ImageEditor.scss
@@ -3,17 +3,17 @@
 @import '../../../theme/constants';
 
 body.view-editview .react-aria-Modal.image-cropper-modal {
-  max-width: unset;
   width: 70vw;
+  max-width: unset;
   height: 70vh;
 }
 
 .image-widget .image-widget-cropper {
   button {
-    border: none;
-    text-decoration: underline;
     padding: 20px 0px;
+    border: none;
     color: rgba(0, 0, 0, 0.9);
+    text-decoration: underline;
   }
 }
 
@@ -22,10 +22,10 @@ body.view-editview .react-aria-Modal.image-cropper-modal {
 }
 
 .image-editor {
+  display: grid;
   width: 100%;
   height: 100%;
   color: $settings-header-color;
-  display: grid;
   grid-template-columns: 100%;
   grid-template-rows: 1fr 80px;
 

--- a/packages/volto-image-editor/src/components/ImageEditor/Editor/ImageEditor.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/Editor/ImageEditor.scss
@@ -2,11 +2,6 @@
 @import '../../../theme/variables';
 @import '../../../theme/constants';
 
-body.view-editview .react-aria-Modal.image-cropper-modal {
-  width: 70vw;
-  max-width: unset;
-  height: 70vh;
-}
 
 .image-widget .image-widget-cropper {
   button {

--- a/packages/volto-image-editor/src/components/ImageEditor/Wrapper/ImageEditorWrapper.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/Wrapper/ImageEditorWrapper.scss
@@ -1,8 +1,11 @@
 @import '../../../theme/variables';
 
 .react-aria-ModalOverlay {
+  z-index: 150;
   .react-aria-Modal.image-cropper-modal {
-    width: 100%;
+    width: 70vw;
+    max-width: unset;
+    height: 70vh;
     border: 0;
     background-color: $settings-header-bg;
 

--- a/packages/volto-image-editor/src/components/ImageEditor/Wrapper/ImageEditorWrapper.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/Wrapper/ImageEditorWrapper.scss
@@ -3,14 +3,13 @@
 .react-aria-ModalOverlay {
   .react-aria-Modal.image-cropper-modal {
     width: 100%;
-    max-width: $editor-width;
     border: 0;
     background-color: $settings-header-bg;
 
     .react-aria-Dialog {
-      display: flex;
+      width: 100%;
+      height: 100%;
       align-items: center;
-      justify-content: center;
       padding: 0;
     }
   }

--- a/packages/volto-image-editor/src/components/ImageEditor/Wrapper/ImageEditorWrapper.tsx
+++ b/packages/volto-image-editor/src/components/ImageEditor/Wrapper/ImageEditorWrapper.tsx
@@ -83,7 +83,7 @@ const ImageEditorWrapper: React.FC<ImageEditorWrapperProps> = ({
     <div className={`image-widget ${className || ''}`}>
       <div className="image-widget-cropper">
         <DialogTrigger>
-          <Button onPress={() => setOpen(true)}>
+          <Button download={false} onPress={() => setOpen(true)}>
             {buttonText || (
               <FormattedMessage id="Edit image" defaultMessage="Edit image" />
             )}

--- a/packages/volto-image-editor/src/components/ImageEditor/components/Navigation/Navigation.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/components/Navigation/Navigation.scss
@@ -4,8 +4,8 @@
 .image-editor-navigation {
   display: flex;
   height: 100%;
-  align-self: flex-end;
   align-items: center;
+  align-self: flex-end;
   justify-content: space-between;
   padding: $image-editor-spacing-lg;
   border-top: solid 1px $image-editor-border-color;

--- a/packages/volto-image-editor/src/components/ImageEditor/components/Navigation/Navigation.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/components/Navigation/Navigation.scss
@@ -4,6 +4,7 @@
 .image-editor-navigation {
   display: flex;
   height: 100%;
+  align-self: flex-end;
   align-items: center;
   justify-content: space-between;
   padding: $image-editor-spacing-lg;

--- a/packages/volto-image-editor/src/components/ImageEditor/components/SettingsModal/SettingsModal.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/components/SettingsModal/SettingsModal.scss
@@ -33,14 +33,16 @@
   }
 
   &__content {
-    display: flex;
+    display: grid;
+    grid-template-columns: 100%;
+    grid-template-rows: 80px 1fr;
     overflow: hidden;
     width: 100%;
+    height: 100%;
     max-height: 100%;
-    flex-direction: column;
     animation: scaleIn $image-editor-transition-fast ease-out;
     background: $settings-body-bg;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 0px 60px rgba(0, 0, 0, 0.5);
   }
 
   &__header {
@@ -60,7 +62,9 @@
   }
 
   &__close {
-    padding: $image-editor-spacing-xs $image-editor-spacing-sm;
+    display: grid;
+    align-self: center;
+    padding: $image-editor-spacing-sm;
     border: none;
     border-radius: $image-editor-border-radius-sm;
     background: transparent;
@@ -86,7 +90,6 @@
   }
 
   &__label {
-    display: block;
     margin-bottom: $image-editor-spacing-sm;
     color: $settings-body-color;
     font-size: 14px;

--- a/packages/volto-image-editor/src/components/ImageEditor/components/SettingsModal/SettingsModal.scss
+++ b/packages/volto-image-editor/src/components/ImageEditor/components/SettingsModal/SettingsModal.scss
@@ -34,8 +34,6 @@
 
   &__content {
     display: grid;
-    grid-template-columns: 100%;
-    grid-template-rows: 80px 1fr;
     overflow: hidden;
     width: 100%;
     height: 100%;
@@ -43,6 +41,8 @@
     animation: scaleIn $image-editor-transition-fast ease-out;
     background: $settings-body-bg;
     box-shadow: 0 0px 60px rgba(0, 0, 0, 0.5);
+    grid-template-columns: 100%;
+    grid-template-rows: 80px 1fr;
   }
 
   &__header {

--- a/packages/volto-image-editor/src/components/ImageEditor/components/SettingsModal/SettingsModal.tsx
+++ b/packages/volto-image-editor/src/components/ImageEditor/components/SettingsModal/SettingsModal.tsx
@@ -32,6 +32,7 @@ import {
   RectangleStencilIcon,
   CircleStencilIcon,
 } from '@plone-collective/volto-image-editor/icons/StencilIcons';
+import BackSVG from '@plone/volto/icons/back.svg';
 import './SettingsModal.scss';
 
 const messages = defineMessages({
@@ -205,7 +206,12 @@ export const SettingsModal: FC<Props> = ({
                 className="image-editor-settings-modal__close"
                 onClick={onToggle}
               >
-                ✕
+                <Icon size="base">
+                  <svg
+                    {...BackSVG.attributes}
+                    dangerouslySetInnerHTML={{ __html: BackSVG.content }}
+                  />
+                </Icon>
               </Button>
             </div>
 

--- a/packages/volto-image-editor/src/components/Widgets/FileWidget.tsx
+++ b/packages/volto-image-editor/src/components/Widgets/FileWidget.tsx
@@ -150,6 +150,8 @@ const FileWidget = (props) => {
       <Grid className="image-widget-grid">
         <Grid.Row stretched>
           <Grid.Column stretched width={mainColumnWidth}>
+            {isImage && <ImageEditorWrapper value={value} setData={setData} />}
+
             <Dropzone
               onDrop={onDrop}
               {...(props.size ? { maxSize: props.size } : {})}
@@ -225,11 +227,6 @@ const FileWidget = (props) => {
               )}
             </div>
           </Grid.Column>
-          {isImage && (
-            <Grid.Column stretched width="2" className={'image-editor-cta'}>
-              <ImageEditorWrapper value={value} setData={setData} />
-            </Grid.Column>
-          )}
         </Grid.Row>
       </Grid>
     </FormFieldWrapper>

--- a/packages/volto-image-editor/src/icons/svg/back.svg
+++ b/packages/volto-image-editor/src/icons/svg/back.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 36 36">
+  <polygon fill-rule="evenodd" points="31 17 8.414 17 18.707 6.707 17.293 5.293 4.586 18 17.293 30.707 18.707 29.293 8.414 19 31 19"/>
+</svg>

--- a/packages/volto-image-editor/src/theme/variables.scss
+++ b/packages/volto-image-editor/src/theme/variables.scss
@@ -15,7 +15,7 @@ $nav-button-color-hover: $color-black !default;
 $nav-button-bg-active: $color-black !default;
 $nav-button-color-active: $color-white !default;
 
-$nav-button-close-color: $color-red !default;
+$nav-button-close-color: $color-gray-dark !default;
 
 $editor-button-bg: $color-gray-dark !default;
 $editor-button-color: $color-white !default;


### PR DESCRIPTION
In this PR I made some adjustments to the image editor to improve the UX and compatibility with VLT. 
According to our figma design I adjusted the button to edit the image:
<img width="851" height="463" alt="Pasted image Image-editor-edit-button" src="https://github.com/user-attachments/assets/32c9024e-60c4-484c-89aa-564fa9d122de" />


I also changed the closing button of the settings while in the editor:
<img width="1324" height="934" alt="Pasted image Image-editor-close-settings-button" src="https://github.com/user-attachments/assets/890d3975-2c3f-4113-a04b-2bece9627d48" />

Now to the improvements in VLT. Before the image editor used the whole screen somehow and that made it look weird:
Before: 
<img width="2555" height="1398" alt="Pasted image image-editor-edit-before" src="https://github.com/user-attachments/assets/11c560f4-8065-4105-9b47-9d234b683695" />

After:
<img width="2555" height="1398" alt="Pasted image image-editor-edit-after" src="https://github.com/user-attachments/assets/e6e9e65a-62ee-449c-a944-6fa560fbecfc" />


I also tested it and it still works on its own.